### PR TITLE
Fix issue whereby menu items were not closing correctly

### DIFF
--- a/sc_app/templates/base.html
+++ b/sc_app/templates/base.html
@@ -33,8 +33,7 @@
       {% block content %}
 
       {% endblock content %}
-    </div>
-    {% include 'js.html' %}
+    </div>    
   </body>
   <footer>
     <div class="footer bg-light">

--- a/sc_app/templates/js.html
+++ b/sc_app/templates/js.html
@@ -1,6 +1,0 @@
-
-<!-- Optional JavaScript -->
-<!-- jQuery first, then Popper.js, then Bootstrap JS -->
-<script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>


### PR DESCRIPTION
All scripts are currently being called twice in the solution. 
This causes JQuery to be called, then Bootstrap, then Popper, and then JQuery again - which breaks functionality intended to be handled by scripts in a particular order.